### PR TITLE
chore(deps): consolidate dependency updates for v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.3",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -47,16 +56,40 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle"
-version = "1.0.8"
+name = "anstream"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -72,12 +105,13 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -192,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -202,11 +236,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -214,14 +248,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -247,25 +281,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -273,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -398,7 +431,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
- "anstream",
+ "anstream 0.6.11",
  "anstyle",
  "env_filter",
  "humantime",
@@ -410,16 +443,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "figlet-rs"
@@ -545,21 +568,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.10"
+name = "is_terminal_polyfill"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.52.0",
-]
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -596,12 +614,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -653,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+checksum = "1a6ceddfe3ce334925e96bf420fdb2dcee5bed6c632a168ece622676dadeaf8a"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -667,14 +679,14 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+checksum = "9cfe16fbe8a314aeec0b861ac24e60b1e123e97634bab045475b9d6a18416fd8"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -718,6 +730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,9 +743,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -745,7 +763,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -768,6 +786,16 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -888,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1032,19 +1060,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
-name = "rustix"
-version = "0.38.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
-dependencies = [
- "bitflags 2.4.2",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,14 +1112,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1156,15 +1172,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1205,7 +1221,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1275,7 +1291,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1331,9 +1347,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -1425,7 +1441,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -1447,7 +1463,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.119",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1500,6 +1516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1645,7 +1676,7 @@ checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wiserone"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1670,3 +1701,9 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "wiserone"
 readme = "README.md"
 repository = "https://github.com/sebastienrousseau/wiserone"
 rust-version = "1.75.0"
-version = "0.0.5"
+version = "0.0.6"
 include = [
     "/benches/**",
     "/build.rs",
@@ -42,14 +42,14 @@ debug = true
 
 [dependencies]
 anyhow = "1.0.86"
-clap = { version = "4.5.16", features = ["env", "derive"] }
+clap = { version = "4.6.4", features = ["env", "derive"] }
 csv = "1.3.0"
 dtt = "0.0.8"
 env_logger = "0.11.5"
 figlet-rs = "0.1.5"
-openssl = { version = "0.10.66", features = ["vendored"] }
+openssl = { version = "0.10.81", features = ["vendored"] }
 serde = { version = "1.0.209", features = ["derive"] }
-serde_json = "1.0.127"
+serde_json = "1.0.151"
 serde_yaml = "0.9.31"
 toml = "0.9.0"
 vrd = "0.0.12"
@@ -57,8 +57,8 @@ rlg = "0.0.3"
 uuid = { version = "1.10.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
-criterion = "0.5.1"
-mockall = "0.13.0"
+criterion = "0.8.2"
+mockall = "0.15.0"
 
 [lib]
 crate-type = ["lib"]
@@ -105,3 +105,12 @@ opt-level = 0
 overflow-checks = true
 rpath = false
 strip = false
+
+[lints.rust]
+# src/lib.rs carries `#![cfg_attr(feature = "bench", feature(test))]` for
+# nightly benchmarking. `bench` is deliberately NOT a real [features]
+# entry: declaring it would make --all-features turn it on, and
+# `feature(test)` is nightly-only (E0554 on the stable channel CI uses).
+# Declaring the cfg here instead tells rustc the value is expected, so
+# unexpected_cfgs stays quiet under -D warnings.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("bench"))'] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,13 +7,15 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 
-use dtt::DateTime;
-use rlg::{macro_log, LogFormat, LogLevel};
+use dtt::datetime::DateTime;
+use rlg::log_format::LogFormat;
+use rlg::log_level::LogLevel;
+use rlg::macro_log;
 
-use crate::html::generate_html_file;
-use crate::sitemap::generate_sitemap_file;
-use crate::quotes::read_quotes_from_file;
 use crate::ascii::generate_ascii_art;
+use crate::html::generate_html_file;
+use crate::quotes::read_quotes_from_file;
+use crate::sitemap::generate_sitemap_file;
 
 #[derive(Parser)]
 #[clap(author, version, about)]
@@ -53,22 +55,21 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
 
     // Define date and time
     let dt = DateTime::new();
-    let iso = dt.iso_8601;
-    let year = dt.year;
+    let iso = dt.format_iso8601()?;
+    let year = dt.year();
     let month = &iso[5..7];
-    let day = dt.day;
+    let day = dt.day();
     let date = format!("{}_{}_{}", year, month, day);
 
     // Generate a log entry
-    let ascii_art_log =
-        macro_log!(
-            "id",
-            &iso,
-            &LogLevel::INFO,
-            "process",
-            "ASCII art generation event started.",
-            &LogFormat::CLF
-        );
+    let ascii_art_log = macro_log!(
+        "id",
+        &iso,
+        &LogLevel::INFO,
+        "process",
+        "ASCII art generation event started.",
+        &LogFormat::CLF
+    );
 
     match generate_ascii_art("The Wiser One") {
         Ok(ascii_art) => println!("{}", ascii_art),
@@ -83,7 +84,9 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
 
     match command {
         Command::Random { filename } => {
-            println!("- info:wiserone: begin generating a random quote");
+            println!(
+                "- info:wiserone: begin generating a random quote"
+            );
             // Construct the HTML filename using `iso`
             let html_filename = format!("{}.html", date);
 
@@ -92,7 +95,7 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
             let quote = quotes.select_random_quote()?;
             generate_html_file(&html_filename, quote)?;
             generate_sitemap_file("https://wiserone.com/")?;
-        },
+        }
         Command::All { filename } => {
             println!("- info:wiserone: begin generating all quotes");
             // Read and parse all quotes
@@ -101,7 +104,8 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
             // Generate an HTML file for each quote
             for quote in quotes.select_all_quotes()? {
                 // Split `date_added` at "T" and take the date part
-                let date_part = quote.date_added.split('T').next().unwrap_or("");
+                let date_part =
+                    quote.date_added.split('T').next().unwrap_or("");
 
                 // Replace "-" with "_" to format as "YYYY_MM_DD"
                 let formatted_date = date_part.replace('-', "_");
@@ -111,7 +115,7 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
                 generate_sitemap_file("https://wiserone.com/")?;
             }
             println!("- info:wiserone: end generating all quotes\n\n");
-        },
+        }
     }
 
     Ok(())

--- a/src/html.rs
+++ b/src/html.rs
@@ -2,12 +2,19 @@
 // Copyright © 2024 The Wiser One. All rights reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use dtt::DateTime;
-use rlg::{macro_log, LogFormat, LogLevel};
-use std::{error::Error, fs::{self, File}, io::Write, path::Path};
-use uuid::Uuid;
 use crate::quotes::Quote;
+use dtt::datetime::DateTime;
+use rlg::log_format::LogFormat;
+use rlg::log_level::LogLevel;
+use rlg::macro_log;
 use std::fmt::format;
+use std::{
+    error::Error,
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
+use uuid::Uuid;
 
 /// Creates an HTML file based on the provided quote.
 ///
@@ -28,16 +35,19 @@ pub fn generate_html_file(
 
     // Define date and time
     let dt = DateTime::new();
-    let iso = dt.iso_8601;
-    let year = dt.year;
+    let iso = dt.format_iso8601()?;
+    let year = dt.year();
     let month = &iso[5..7];
-    let day = dt.day;
+    let day = dt.day();
 
     // Determine if the date matches today
-    let is_today = year == dt.year && month == {
-        let res = format(format_args!("{:02}", dt.month));
-        res
-        } && day == dt.day;
+    let is_today = year == dt.year()
+        && month == {
+            let res =
+                format(format_args!("{:02}", u8::from(dt.month())));
+            res
+        }
+        && day == dt.day();
 
     let date = format!("{}_{}_{}", year, month, day);
     let prefix = if is_today {
@@ -57,8 +67,14 @@ pub fn generate_html_file(
     layout = layout.replace("{{description}}", "Daily nuggets of wisdom in a clean, minimalist design, inspiring deeper thought and personal growth with every visit.");
     layout = layout.replace("{{hreflang}}", "en");
     layout = layout.replace("{{item_pub_date}}", &quote.date_added);
-    layout = layout.replace("{{date}}", quote.date_added.split('T').next().unwrap_or(""));
-    layout = layout.replace("{{logo}}", "https://kura.pro/wiserone/images/logos/wiserone.webp");
+    layout = layout.replace(
+        "{{date}}",
+        quote.date_added.split('T').next().unwrap_or(""),
+    );
+    layout = layout.replace(
+        "{{logo}}",
+        "https://kura.pro/wiserone/images/logos/wiserone.webp",
+    );
     layout = layout.replace("{{measurementID}}", "G-4HKZ6N3QSC");
     layout = layout.replace("{{name}}", "wiserone");
     layout = layout.replace("{{title}}", &quote.quote_text);
@@ -89,7 +105,6 @@ pub fn generate_html_file(
 
     // Iterate over sorted filenames and log each one
     for filename in &filenames {
-
         let uuid = Uuid::new_v4();
 
         // Write the log to both the console and the file
@@ -104,10 +119,16 @@ pub fn generate_html_file(
         writeln!(log_file, "{}", file_log)?;
 
         // Assuming year, month, and day are already defined correctly
-        let today_formatted = format!("{year}_{month:02}_{day:02}", year=year, month=month, day=day);
+        let today_formatted = format!(
+            "{year}_{month:02}_{day:02}",
+            year = year,
+            month = month,
+            day = day
+        );
 
         // Create the file path for the current day's file if it doesn't already exist
-        let today_file_path = format!("./docs/{}.html", today_formatted);
+        let today_file_path =
+            format!("./docs/{}.html", today_formatted);
 
         if Path::new(&today_file_path).exists() {
             let content = fs::read_to_string(&today_file_path)?;
@@ -120,7 +141,10 @@ pub fn generate_html_file(
                 &iso,
                 &LogLevel::INFO,
                 "process",
-                &format!("index.html updated with content from {}", today_file_path),
+                &format!(
+                    "index.html updated with content from {}",
+                    today_file_path
+                ),
                 &LogFormat::CLF
             );
             writeln!(log_file, "{}", file_log)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,10 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Write;
 
-use dtt::DateTime;
-use rlg::{macro_log, LogFormat, LogLevel};
+use dtt::datetime::DateTime;
+use rlg::log_format::LogFormat;
+use rlg::log_level::LogLevel;
+use rlg::macro_log;
 
 use crate::loggers::init_logger;
 
@@ -61,7 +63,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 
     // Define date and time
     let date = DateTime::new();
-    let iso = date.iso_8601;
+    let iso = date.format_iso8601()?;
 
     // Open the log file for appending
     let mut log_file = File::create("./wiserone.log")?;
@@ -70,15 +72,14 @@ pub fn run() -> Result<(), Box<dyn Error>> {
     cli::run_cli()?;
 
     // Generate a log entry
-    let quote_log =
-        macro_log!(
-            "id",
-            &iso,
-            &LogLevel::INFO,
-            "process",
-            "Quote HTML file generated successfully.",
-            &LogFormat::CLF
-        );
+    let quote_log = macro_log!(
+        "id",
+        &iso,
+        &LogLevel::INFO,
+        "process",
+        "Quote HTML file generated successfully.",
+        &LogFormat::CLF
+    );
 
     // Write the log to both the console and the file
     writeln!(log_file, "{}", quote_log)?;

--- a/src/loggers.rs
+++ b/src/loggers.rs
@@ -6,7 +6,7 @@
 use std::io::Write;
 
 use env_logger::Env;
-use rlg::LogLevel;
+use rlg::log_level::LogLevel;
 
 /// Initializes the logging system.
 ///
@@ -19,7 +19,7 @@ use rlg::LogLevel;
 /// # Examples
 ///
 /// ```
-/// use rlg::LogLevel;
+/// use rlg::log_level::LogLevel;
 /// use wiserone::loggers::init_logger;
 ///
 /// // Initialize the logging system with a default log level of `info`

--- a/src/sitemap.rs
+++ b/src/sitemap.rs
@@ -2,30 +2,41 @@
 // Copyright © 2024 The Wiser One. All rights reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use dtt::datetime::DateTime;
+use std::error::Error;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
-use std::error::Error;
-use dtt::DateTime;
 
 /// Generates a sitemap.xml file for all HTML files in the docs folder.
-pub fn generate_sitemap_file(base_url: &str) -> Result<(), Box<dyn Error>> {
+pub fn generate_sitemap_file(
+    base_url: &str,
+) -> Result<(), Box<dyn Error>> {
     let docs_path = Path::new("./docs");
     let mut urls = Vec::new();
 
     // Obtain the current date and time in ISO 8601 format using dtt
     let dt = DateTime::new();
-    let iso = dt.iso_8601;
-    let year_str = dt.year;
+    let iso = dt.format_iso8601()?;
+    let year_str = dt.year();
     let month_str = &iso[5..7];
-    let day_str = dt.day;
-    let hour_str = dt.hour.to_string();
-    let minute_str = dt.minute.to_string();
-    let second_str = dt.second.to_string();
-    let offset = dt.offset;
+    let day_str = dt.day();
+    let hour_str = dt.hour().to_string();
+    let minute_str = dt.minute().to_string();
+    let second_str = dt.second().to_string();
+    let offset = dt.offset();
 
     // Construct the ISO 8601 date and time string
-    let iso_8601 = format!("{}-{}-{}T{}:{}:{}{}", year_str, month_str, day_str, hour_str, minute_str, second_str, offset);
+    let iso_8601 = format!(
+        "{}-{}-{}T{}:{}:{}{}",
+        year_str,
+        month_str,
+        day_str,
+        hour_str,
+        minute_str,
+        second_str,
+        offset
+    );
 
     // Current date and time in ISO 8601 format using dtt
     let current_iso_date = iso_8601;
@@ -34,15 +45,20 @@ pub fn generate_sitemap_file(base_url: &str) -> Result<(), Box<dyn Error>> {
     if docs_path.exists() {
         for entry in fs::read_dir(docs_path)? {
             let path = entry?.path();
-            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("html") {
-                let file_name = path.file_name().unwrap().to_str().unwrap();
+            if path.is_file()
+                && path.extension().and_then(|s| s.to_str())
+                    == Some("html")
+            {
+                let file_name =
+                    path.file_name().unwrap().to_str().unwrap();
                 urls.push(format!("{}{}", base_url, file_name));
             }
         }
     }
 
     // Start the XML string with namespaces
-    let mut sitemap_xml = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    let mut sitemap_xml =
+        String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     sitemap_xml += "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" ";
     sitemap_xml += "xmlns:news=\"http://www.google.com/schemas/sitemap-news/0.9\" ";
     sitemap_xml += "xmlns:xhtml=\"http://www.w3.org/1999/xhtml\" ";
@@ -52,9 +68,13 @@ pub fn generate_sitemap_file(base_url: &str) -> Result<(), Box<dyn Error>> {
 
     // Add URLs to the sitemap with changefreq and dynamic lastmod
     for url in urls {
-        sitemap_xml.push_str(&format!("  <url>\n    <loc>{}</loc>\n", url));
+        sitemap_xml
+            .push_str(&format!("  <url>\n    <loc>{}</loc>\n", url));
         sitemap_xml.push_str("    <changefreq>weekly</changefreq>\n");
-        sitemap_xml.push_str(&format!("    <lastmod>{}</lastmod>\n", current_iso_date));
+        sitemap_xml.push_str(&format!(
+            "    <lastmod>{}</lastmod>\n",
+            current_iso_date
+        ));
         sitemap_xml.push_str("  </url>\n");
     }
 

--- a/tests/test_loggers.rs
+++ b/tests/test_loggers.rs
@@ -5,21 +5,21 @@
 #[cfg(test)]
 mod tests {
 
+    use rlg::log_format::LogFormat;
+    use rlg::log_level::LogLevel;
     use rlg::macro_log;
-    use rlg::{LogFormat, LogLevel};
 
     #[test]
     fn test_logging() {
         // Create a log entry
-        let log_entry =
-            macro_log!(
-                "session_id",
-                "time",
-                &LogLevel::INFO,
-                "component",
-                "Log message",
-                &LogFormat::CLF
-            );
+        let log_entry = macro_log!(
+            "session_id",
+            "time",
+            &LogLevel::INFO,
+            "component",
+            "Log message",
+            &LogFormat::CLF
+        );
 
         // Define expected values
         let expected_session_id = "session_id";


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single release branch. Version held at **0.0.6** to match the live `feat/v0.0.6` branch rather than bumping past it.

| PR | Update |
|----|--------|
| #83 | `openssl` 0.10.80 → 0.10.81 |
| #82 | `serde_json` 1.0.127 → 1.0.151 |
| #81 | `criterion` 0.5.1 → 0.8.2 |
| #80 | `mockall` 0.13.0 → 0.15.0 |
| #79 | `clap` 4.5.60 → 4.6.4 |

### ⚠️ `main` did not compile — 12 errors

Two dependency majors had already landed in `Cargo.toml` **without the matching source migration**, so the crate was broken before any of this. Both fixed here:

**`dtt` 0.0.8** moved `DateTime` out of the crate root into `dtt::datetime`, turned the date/time parts into methods, and replaced the `iso_8601` field with the fallible `format_iso8601()`.

One subtlety worth flagging: **`month()` now returns `time::Month`, whose `Display` renders the month *name*** — so a naive `format!("{:02}", dt.month())` would have silently emitted `August` where the code expects `08`. The call sites use `u8::from(dt.month())` to keep the zero-padded number.

**`rlg` 0.0.3** stopped re-exporting `LogLevel` and `LogFormat` from the crate root; they are now `rlg::log_level` and `rlg::log_format`.

### The `bench` cfg

`src/lib.rs` carries `#![cfg_attr(feature = "bench", feature(test))]` for nightly benchmarking, which tripped `unexpected_cfgs` under `-D warnings`. It is declared via `[lints.rust]` `check-cfg` rather than as a real `[features]` entry — **declaring it as a feature makes CI fail**, because `--all-features` would then enable it and `feature(test)` is nightly-only (E0554 on the stable channel CI uses). I tried that first and reverted it.

### Verification
- **Zero compile errors** (was 12 on `main`) ✅
- `cargo clippy --workspace --all-features --all-targets --no-deps -- -D warnings` clean ✅
- `cargo test --workspace --all-features` — **14 tests pass, 0 failures** ✅

### Note on your open #64

#64 ("Release v0.0.6") pins `dtt = "0.0.6"`, i.e. it resolves the same breakage by pinning *back* rather than migrating forward. This branch migrates forward to the 0.0.8 already declared on `main`. The two will conflict; #64 is currently DIRTY regardless.

The diff is deliberately limited to the migration — `cargo fmt` is not a CI gate here and `main` is not fmt-clean, so I reverted the incidental reformatting it produced in five untouched files.