### PR TITLE
chore(deps): bump dtt to 0.0.11, figlet-rs to 1.0.0, env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,7 +142,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
  "object",
  "rustc-demangle",
 ]
@@ -158,6 +164,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -280,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,15 +415,12 @@ dependencies = [
 
 [[package]]
 name = "dtt"
-version = "0.0.8"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0f956d085fb3371b9ab70b662dc444d2ebc60e2963eed84f1fc3fb3f56549c"
+checksum = "d3ad961df245c82bc67098f5bd69640d3194a081df8f0f5df1f017db4a05292a"
 dependencies = [
- "lazy_static",
- "paste",
- "regex",
+ "pastey",
  "serde",
- "serde_derive",
  "serde_json",
  "thiserror",
  "time",
@@ -446,9 +464,22 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "figlet-rs"
-version = "0.1.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4742a071cd9694fc86f9fa1a08fa3e53d40cc899d7ee532295da2d085639fbc5"
+checksum = "aad4cf7e378685c1af30f41b4832c29700325524c648d47752cabd5b97e7b09b"
+dependencies = [
+ "zip",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.9",
+]
 
 [[package]]
 name = "foreign-types"
@@ -598,12 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +675,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -822,10 +857,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pin-project-lite"
@@ -1155,6 +1190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,22 +1247,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1682,7 +1723,7 @@ dependencies = [
  "clap",
  "criterion",
  "csv",
- "dtt 0.0.8",
+ "dtt 0.0.11",
  "env_logger",
  "figlet-rs",
  "mockall",
@@ -1701,6 +1742,18 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ debug = true
 anyhow = "1.0.86"
 clap = { version = "4.6.4", features = ["env", "derive"] }
 csv = "1.3.0"
-dtt = "0.0.8"
+dtt = "0.0.11"
 env_logger = "0.11.5"
-figlet-rs = "0.1.5"
+figlet-rs = "1.0.0"
 openssl = { version = "0.10.81", features = ["vendored"] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = "1.0.151"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -38,4 +38,3 @@ fn main() -> Result<(), Box<dyn Error>> {
     // If everything executes successfully, return Ok.
     Ok(())
 }
-

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -2,14 +2,14 @@
 // Copyright © 2024 The Wiser One. All rights reserved.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use figlet_rs::FIGfont;
+use figlet_rs::FIGlet;
 use std::error::Error;
 use std::fmt;
 
 /// Error type for ASCII art generation failures.
 #[derive(Debug)]
 pub enum ArtError {
-    /// Represents a failure to load the FIGfont.
+    /// Represents a failure to load the FIGlet.
     FontLoadError,
     /// Represents a failure to convert text to ASCII art.
     ConversionError,
@@ -19,7 +19,7 @@ impl fmt::Display for ArtError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Self::FontLoadError => {
-                write!(f, "Failed to load FIGfont")
+                write!(f, "Failed to load FIGlet")
             }
             Self::ConversionError => {
                 write!(f, "Failed to convert text to ASCII art")
@@ -30,7 +30,7 @@ impl fmt::Display for ArtError {
 
 impl Error for ArtError {}
 
-/// Generates ASCII art from the given text using the standard `FIGfont`.
+/// Generates ASCII art from the given text using the standard `FIGlet`.
 ///
 /// # Arguments
 ///
@@ -40,14 +40,13 @@ impl Error for ArtError {}
 ///
 /// This function returns an `Err` in the following situations:
 ///
-/// - If the standard `FIGfont` fails to load (`FontLoadError`).
+/// - If the standard `FIGlet` fails to load (`FontLoadError`).
 /// - If the text cannot be converted to ASCII art (`ConversionError`).
 ///
 pub fn generate_ascii_art(text: &str) -> Result<String, ArtError> {
     let standard_font =
-        FIGfont::standard().map_err(|_| ArtError::FontLoadError)?;
-    let figure = standard_font
-        .convert(text)
-        .ok_or(ArtError::ConversionError)?;
+        FIGlet::standard().map_err(|_| ArtError::FontLoadError)?;
+    let figure =
+        standard_font.convert(text).ok_or(ArtError::ConversionError)?;
     Ok(figure.to_string())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ pub fn run_cli() -> Result<(), Box<dyn Error>> {
 
     // Define date and time
     let dt = DateTime::new();
-    let iso = dt.format_iso8601()?;
+    let iso = dt.format_rfc3339()?;
     let year = dt.year();
     let month = &iso[5..7];
     let day = dt.day();

--- a/src/html.rs
+++ b/src/html.rs
@@ -35,7 +35,7 @@ pub fn generate_html_file(
 
     // Define date and time
     let dt = DateTime::new();
-    let iso = dt.format_iso8601()?;
+    let iso = dt.format_rfc3339()?;
     let year = dt.year();
     let month = &iso[5..7];
     let day = dt.day();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 
     // Define date and time
     let date = DateTime::new();
-    let iso = date.format_iso8601()?;
+    let iso = date.format_rfc3339()?;
 
     // Open the log file for appending
     let mut log_file = File::create("./wiserone.log")?;

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use csv;
-use serde_json;
 use serde::{Deserialize, Serialize};
+use serde_json;
 use std::{error::Error, fmt, fs, path::Path};
 use vrd::Random;
 
@@ -44,7 +44,9 @@ impl Quotes {
     ///
     /// Returns a reference to a randomly selected `Quote` or an error
     /// if there are no quotes available.
-    pub fn select_random_quote(&mut self) -> Result<&Quote, Box<dyn Error>> {
+    pub fn select_random_quote(
+        &mut self,
+    ) -> Result<&Quote, Box<dyn Error>> {
         if self.quotes.is_empty() {
             return Err("No available quotes".into());
         }
@@ -52,7 +54,8 @@ impl Quotes {
         // Random number generator.
         let mut rng = Random::new();
         // Random index selection.
-        let rand_index = rng.int(0, self.quotes.len() as i32 - 1) as usize;
+        let rand_index =
+            rng.int(0, self.quotes.len() as i32 - 1) as usize;
 
         Ok(&self.quotes[rand_index])
     }
@@ -62,12 +65,15 @@ impl Quotes {
     /// # Returns
     ///
     /// Returns all quotes or an error if no quotes are available.
-    pub fn select_all_quotes(&self) -> Result<Vec<&Quote>, Box<dyn Error>> {
+    pub fn select_all_quotes(
+        &self,
+    ) -> Result<Vec<&Quote>, Box<dyn Error>> {
         if self.quotes.is_empty() {
             return Err("No available quotes".into());
         }
 
-        let mut sorted_quotes = self.quotes.iter().collect::<Vec<&Quote>>();
+        let mut sorted_quotes =
+            self.quotes.iter().collect::<Vec<&Quote>>();
         sorted_quotes.sort_by_key(|quote| &quote.date_added);
 
         Ok(sorted_quotes)
@@ -91,8 +97,12 @@ impl fmt::Display for QuoteError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             QuoteError::IOError(err) => write!(f, "I/O Error: {}", err),
-            QuoteError::ParseError(msg) => write!(f, "Parse Error: {}", msg),
-            QuoteError::NoQuotesAvailable => write!(f, "No Quotes Available"),
+            QuoteError::ParseError(msg) => {
+                write!(f, "Parse Error: {}", msg)
+            }
+            QuoteError::NoQuotesAvailable => {
+                write!(f, "No Quotes Available")
+            }
         }
     }
 }
@@ -135,17 +145,23 @@ impl From<csv::Error> for QuoteError {
 ///
 /// Returns a `Quotes` struct if successful, or an error if the file
 /// cannot be read or parsed.
-pub fn read_quotes_from_file(file_path: &str) -> Result<Quotes, QuoteError> {
+pub fn read_quotes_from_file(
+    file_path: &str,
+) -> Result<Quotes, QuoteError> {
     let path = Path::new(file_path);
     match path.extension().and_then(|s| s.to_str()) {
         Some("json") => read_quotes_from_json(file_path),
         Some("csv") => read_quotes_from_csv(file_path),
-        _ => Err(QuoteError::ParseError("Unsupported file format".into())),
+        _ => Err(QuoteError::ParseError(
+            "Unsupported file format".into(),
+        )),
     }
 }
 
 /// Reads and parses quotes from a JSON file.
-fn read_quotes_from_json(file_path: &str) -> Result<Quotes, QuoteError> {
+fn read_quotes_from_json(
+    file_path: &str,
+) -> Result<Quotes, QuoteError> {
     let file_content = fs::read_to_string(file_path)?;
     let quotes: Quotes = serde_json::from_str(&file_content)?;
     Ok(quotes)
@@ -154,6 +170,8 @@ fn read_quotes_from_json(file_path: &str) -> Result<Quotes, QuoteError> {
 /// Reads and parses quotes from a CSV file.
 fn read_quotes_from_csv(file_path: &str) -> Result<Quotes, QuoteError> {
     let mut rdr = csv::Reader::from_path(file_path)?;
-    let quotes = rdr.deserialize().collect::<Result<Vec<Quote>, csv::Error>>()?;
+    let quotes = rdr
+        .deserialize()
+        .collect::<Result<Vec<Quote>, csv::Error>>()?;
     Ok(Quotes::new(quotes))
 }

--- a/src/sitemap.rs
+++ b/src/sitemap.rs
@@ -17,7 +17,7 @@ pub fn generate_sitemap_file(
 
     // Obtain the current date and time in ISO 8601 format using dtt
     let dt = DateTime::new();
-    let iso = dt.format_iso8601()?;
+    let iso = dt.format_rfc3339()?;
     let year_str = dt.year();
     let month_str = &iso[5..7];
     let day_str = dt.day();

--- a/tests/test_quotes.rs
+++ b/tests/test_quotes.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashSet;
-use wiserone::quotes::{Quotes, Quote};
+use wiserone::quotes::{Quote, Quotes};
 
 /// Test the creation and field access of the Quote struct.
 #[test]
@@ -63,7 +63,8 @@ fn test_random_quote_selection() {
         Err(e) => panic!("Failed to select a random quote: {}", e),
     };
 
-    let quotes_texts: HashSet<_> = quotes.quotes.iter().map(|q| &q.quote_text).collect();
+    let quotes_texts: HashSet<_> =
+        quotes.quotes.iter().map(|q| &q.quote_text).collect();
 
     assert!(quotes_texts.contains(&selected_quote_text));
 }
@@ -140,7 +141,9 @@ fn test_select_all_quotes_empty_vector() {
     let quotes = Quotes::new(Vec::new()); // empty vector
 
     match quotes.select_all_quotes() {
-        Ok(_) => panic!("Expected an error for empty quotes vector, but got Ok"),
+        Ok(_) => panic!(
+            "Expected an error for empty quotes vector, but got Ok"
+        ),
         Err(e) => assert_eq!(e.to_string(), "No available quotes"),
     }
 }
@@ -156,7 +159,8 @@ fn test_quote_serialization_deserialization() {
     };
 
     let serialized = serde_json::to_string(&quote).unwrap();
-    let deserialized: Quote = serde_json::from_str(&serialized).unwrap();
+    let deserialized: Quote =
+        serde_json::from_str(&serialized).unwrap();
 
     assert_eq!(quote, deserialized);
 }

--- a/tests/test_sitemap.rs
+++ b/tests/test_sitemap.rs
@@ -4,12 +4,13 @@
 
 #[cfg(test)]
 mod tests {
-    use wiserone::sitemap::generate_sitemap_file;
-    use std::fs;
     use std::error::Error;
+    use std::fs;
+    use wiserone::sitemap::generate_sitemap_file;
 
     #[test]
-    fn test_generate_sitemap_file_no_html_files() -> Result<(), Box<dyn Error>> {
+    fn test_generate_sitemap_file_no_html_files(
+    ) -> Result<(), Box<dyn Error>> {
         // Ensure the docs directory is empty
         fs::remove_dir_all("./docs")?;
         fs::create_dir("./docs")?;


### PR DESCRIPTION
Supersedes #85, #86, #87. **No version bump** — `feat/v0.0.6` is unmerged.

### Two of the three are breaking

- **dtt 0.0.11** renamed `format_iso8601()` → `format_rfc3339()`. Four files call it (`cli.rs`, `html.rs`, `lib.rs`, `sitemap.rs`), so #86 on its own leaves the crate failing to compile.
- **figlet-rs 1.0.0** renamed `FIGfont` → `FIGlet`. The rest of that API (`standard()`, `convert()`) is unchanged, so the rename is the entire migration.

### The three lockfile diffs also conflict with each other

Applying all three patches leaves `thiserror` specified twice, and cargo refuses to parse the file:

```
error: failed to parse lock file
Caused by: package `thiserror` is specified twice in the lockfile
```

Regenerated from `main` with `cargo update -p` for the three packages rather than hand-merging the conflicting diffs.

### Verification

`cargo build --workspace`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo test --workspace` (14 passed) all pass.